### PR TITLE
fix(gitconfig): fix URL for f**kit alias

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -109,7 +109,7 @@
 [credential]
 	helper = cache
 [pull]
-	rebase = true	; Only rebase when pulling, no mrege.
+	rebase = true	; Only rebase when pulling, no merge.
 	ff = only	; Allow only fast-forward (no merge commit) rebase when pulling with rebase.
 [push]
 	;default = upstream

--- a/.config/git/config
+++ b/.config/git/config
@@ -40,7 +40,7 @@
 	dic = diff --cached
 	diffc = diff --cached
 	ft = fetch
-	fuckit = !"git add .; git commit -am \"$(curl -s http://whatthecommit.com/index.txt)\""
+	fuckit = !"git add .; git commit -am \"$(curl -s https://whatthecommit.com/index.txt)\""
 	gvimerge = mergetool -t gvimdiff
 	h = help
 	l = log


### PR DESCRIPTION
which is a permanent redirect but curl isn't following
```
$ curl -s http://whatthecommit.com/index.txt -i
HTTP/1.1 308 Permanent Redirect
Connection: close
Location: https://whatthecommit.com/index.txt
Server: Caddy
Date: Tue, 05 May 2026 20:39:16 GMT
Content-Length: 0
```